### PR TITLE
downrev pysftp to 0.2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ py==1.11.0
 pymongo==3.12.1
 pyparsing==3.0.6
 pyrsistent==0.18.0
-pysftp==0.2.9
+pysftp==0.2.8
 pytest==6.2.1
 python-dateutil==2.8.1
 python-json-logger==2.0.1


### PR DESCRIPTION
**downrev pysftp to 0.2.8*
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/SS-207

# What does this Pull Request do?
downrevs the library that via_export.py uses for sftp, pysftp, from 0.2.9 to 0.2.8, because 0.2.9 cannot correctly check host keys. https://stackoverflow.com/questions/65002585/connection-object-has-no-attribute-sftp-live-when-pysftp-connection-fails

# How should this be tested?

this has been deployed to dev. 

to test on dev, either run the integration test https://ltsds-cloud-dev-1.lib.harvard.edu:25003/integration  or log into the container and run` ~/ltstools/via/bin/via_export.py -p primo incr`. 

then look at the logfile in `~/ltstools/via/log/viaLOGFILE`. you should see that it successfully published to primo.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
