### PR TITLE
skip parsing deleted file if parse fails

### DIFF
--- a/app/jstor_publisher.py
+++ b/app/jstor_publisher.py
@@ -413,7 +413,10 @@ Update job timestamp file"""
                 if len(fnmatch.filter(os.listdir(deletesDir), '*.xml')) > 0:
                     for filename in os.listdir(deletesDir):
                         if (filename.endswith(".xml") and not filename.startswith("via_export_del_")):
-                            setspec, identifier = (filename[:-4]).split("_", 1)
+                            try:
+                                setspec, identifier = (filename[:-4]).split("_", 1)
+                            except:
+                                continue
                             repository_name = self.repositories[setSpec]["displayname"]
                             repo_short_name = self.repositories[setSpec]["shortname"]
                             try:


### PR DESCRIPTION
**skip parsing deleted file if parse fails*
* * *

**JIRA Ticket**:  https://jira.huit.harvard.edu/browse/SS-316

# What does this Pull Request do?

prevents publisher from stopping on failed parsing of delete files

# How should this be tested?
this is on dev.  running the itest should pass.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? y

# Interested parties
Tag (@ mention) interested parties @awoods 
