### PR TITLE
change delete file names to be parsed/concatenated

### DIFF
--- a/ltstools/via/bin/via_export.py
+++ b/ltstools/via/bin/via_export.py
@@ -270,13 +270,15 @@ def prep_incr_export(configSets, dateStamp):
 		# Open each export file and grab any record IDs it might contain
 		recordIds = []
 		os.chdir(localDir)
-		for file in glob('via_export_incr_*.xml'):
-			with open(file) as input:
-				for line in input:
-					match = reRecordId.match(line)
-					if match:
-						recordIds.append(match.group(1))
-						os.remove(file)
+		delFilenamePattern = r'^\d{3,4}_.*\.xml$'
+		for file in glob('*.xml'):
+			if re.match(delFilenamePattern , file):
+				with open(file) as input:
+					for line in input:
+						match = reRecordId.match(line)
+						if match:
+							recordIds.append(match.group(1))
+							os.remove(file)
 					
 		# Write file of deleted records if any were found
 		if len(recordIds) > 0:


### PR DESCRIPTION
**Change delete file names to be parsed/concatenated.**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/LTSMAINT-741

# What does this Pull Request do?
The publisher was expecting the file name to look for deletes to be of format
via_export_incr_*.xml
but deletes are now in files named <setid>_<recid>.xml
This pr is now looking in files with the proper format name

# How should this be tested?

- Deploy to dev (done)
- Run integration test
- On dev go to /docker/jstorforum/PROCESSING/DELETES
- Look for these files:
ls -1 via_export_del_20230615.*
via_export_del_20230615.tar.gz
via_export_del_20230615.xml
(swap in proper date)
- confirm proper format:
cat via_export_del_20230615.xml
<?xml version="1.0" encoding="UTF-8" ?>
<ino:request xmlns:ino="http://namespaces.softwareag.com/tamino/response2">
	<ino:object>
		<viaRecord>
			<recordId>9129773</recordId>
			<deleted>Y</deleted>
		</viaRecord>
	</ino:object>
</ino:request>

- sftp to the alma dropbox and confirm the tar.gz delete file is there (done)
-
# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No, this was a bug fix; I confirmed that our delete is still showing properly in mongo

