### PR TITLE
fix concatenation of hollis recs

### DIFF
--- a/ltstools/bin/concat-files.sh
+++ b/ltstools/bin/concat-files.sh
@@ -49,7 +49,7 @@ then
    rm -f /tmp/JSTORFORUM/export/lc/viafull_${JOBTICKETID}_${SETNAME}_${DATESTAMP}.tmp
 
    #PRIMO
-   find /tmp/JSTORFORUM/transformed/$SETNAME -type f | grep 'hollis' | xargs cat > /tmp/JSTORFORUM/export/primo/viafull_${JOBTICKETID}_${SETNAME}_${DATESTAMP}.tmp
+   find /tmp/JSTORFORUM/transformed/$SETNAME_hollis -type f | xargs cat > /tmp/JSTORFORUM/export/primo/viafull_${JOBTICKETID}_${SETNAME}_${DATESTAMP}.tmp
    cat /home/jstorforumadm/ltstools/conf/taminohead.txt /tmp/JSTORFORUM/export/primo/viafull_${JOBTICKETID}_${SETNAME}_${DATESTAMP}.tmp /home/jstorforumadm/ltstools/conf/taminotail.txt > /tmp/JSTORFORUM/export/primo/viafull_${JOBTICKETID}_${SETNAME}_${DATESTAMP}.xml
    tar -czvf /tmp/JSTORFORUM/export/primo/$TARBALL /tmp/JSTORFORUM/export/primo/viafull_${JOBTICKETID}_${SETNAME}_${DATESTAMP}.xml
    rm -f /tmp/JSTORFORUM/export/primo/viafull_${JOBTICKETID}_${SETNAME}_${DATESTAMP}.tmp


### PR DESCRIPTION
**Fix concatenation of hollis recs**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/LTSMAINT-742

# What does this Pull Request do?
The method of finding which hollis files for a set was missing directories named <setname>_hollis, so the concatenated file and tar.gz was empty; a simple change in the concat-files.sh fixes this

# How should this be tested?

-Deploy to dev (done)
- Run a full harvest of a small set (warren - done)
- look in /tmp/JSTORFORUM/export/primo for: (done)
> ls -1 viafull_20230614_MED-Warren_20230615.*
viafull_20230614_MED-Warren_20230615.tar.gz
viafull_20230614_MED-Warren_20230615.xml

Confirm the xml file (and the tar.gz have concatenated recs and are not empty (done)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? N
- integration tests? N - bug fix

# Interested parties
Tag (@ mention) interested parties
